### PR TITLE
Add logic to control matrix types

### DIFF
--- a/bin/run_control_workflow.sh
+++ b/bin/run_control_workflow.sh
@@ -2,4 +2,4 @@
 
 export WORKFLOW_ROOT=`pwd`
 
-nextflow run main.nf -profile cluster
+nextflow run main.nf -profile standard

--- a/data/test.txt
+++ b/data/test.txt
@@ -1,3 +1,3 @@
-E-MTAB-6386,3,id,Characteristic.cell.type.
-E-GEOD-36552,5,id,Characteristic.cell.type.
+E-MTAB-6386,droplet,3,id,Characteristic.cell.type.
+E-GEOD-106973,smart-seq,13,id,Characteristic.cell.type.
 

--- a/data/test.txt
+++ b/data/test.txt
@@ -1,3 +1,3 @@
-E-MTAB-6386,normalised,tpm,3,id,Characteristic.cell.type.
-E-GEOD-36552,normalised,tpm,5,id,Characteristic.cell.type.
+E-MTAB-6386,3,id,Characteristic.cell.type.
+E-GEOD-36552,5,id,Characteristic.cell.type.
 

--- a/envs/load_data.yaml
+++ b/envs/load_data.yaml
@@ -5,4 +5,4 @@ channels:
   - defaults
   - ebi-gene-expression-group
 dependencies:
-  - atlas-data-import=0.0.4
+  - atlas-data-import=0.0.5

--- a/envs/nextflow.yaml
+++ b/envs/nextflow.yaml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - nextflow=19.10.0 
+  - nextflow=20.01.0

--- a/main.nf
+++ b/main.nf
@@ -31,17 +31,23 @@ process fetch_training_datasets {
     conda "${baseDir}/envs/load_data.yaml"
 
     input:
-        tuple val(dataset_id), val(num_clust), val(barcode_col), val(cell_type_col), val(matrix_type) from IMPORT_PARAMS
+        tuple val(dataset_id), val(seq_method), val(num_clust), val(barcode_col), val(cell_type_col), val(matrix_type) from IMPORT_PARAMS
 
     output:
         tuple file("data"), val(dataset_id), val(barcode_col), val(cell_type_col), val(matrix_type) into TRAINING_DATA
         val(num_clust) into N_CLUST
 
     """
+    if [ ${seq_method} ==  "droplet" ]; then 
+        MATRIX_TYPE_UPD="CPM"
+    else
+        MATRIX_TYPE_UPD=${matrix_type}
+    fi
+
     get_experiment_data.R\
                 --accesssion-code ${dataset_id}\
                 --config-file ${params.data_import.config_file}\
-                --matrix-type ${matrix_type}\
+                --matrix-type \$MATRIX_TYPE_UPD\
                 --output-dir-name data\
                 --get-sdrf ${params.data_import.get_sdrf}\
                 --get-condensed-sdrf ${params.data_import.get_cond_sdrf}\

--- a/main.nf
+++ b/main.nf
@@ -28,7 +28,6 @@ IMPORT_PARAMS = Channel
                 .combine(UNIQUE_MATRIX_TYPES)
 
 process fetch_training_datasets {
-    publishDir "${baseDir}/data/${dataset_id}", mode: 'copy'
     conda "${baseDir}/envs/load_data.yaml"
 
     input:
@@ -55,7 +54,6 @@ process fetch_training_datasets {
 // to avoid problems with sdrf-barcode matching, unmelt condensed SDRF and use it in downstream processes
 if(params.unmelt_sdrf.run == "True"){
     process unmelt_condensed_sdrf {
-        publishDir "${baseDir}/data/${dataset_id}", mode: 'copy'
         conda "${baseDir}/envs/exp_metadata.yaml"
 
         input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,7 +39,7 @@ params {
 
     garnett {
         run = "True" // boolean - should the sub-workflow be run (True/False)?
-        matrix_type = "CPM" // must be either "raw", "filtered", "TPM" or "CPM"
+        matrix_type = "CPM" // must be either "raw", "filtered", "TPM" or "CPM" (NB: TPM is only relevant for smart-seq based  experiments; CPM matrices will be downloaded for droplet-based experiments by default)
         training_10x_dir = "$baseDir/data/data_10X"
         training_cds_gene_id_type = "ENSEMBL"
         training_dataset_id = ""

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,7 +39,7 @@ params {
 
     garnett {
         run = "True" // boolean - should the sub-workflow be run (True/False)?
-        matrix_type = "CPM" // must be either "raw", "filtered" or "normalised"
+        matrix_type = "CPM" // must be either "raw", "filtered", "TPM" or "CPM"
         training_10x_dir = "$baseDir/data/data_10X"
         training_cds_gene_id_type = "ENSEMBL"
         training_dataset_id = ""
@@ -55,7 +55,7 @@ params {
 
     scmap_cell{
         run = "True"
-        matrix_type = "TPM" // must be either "raw", "filtered" or "normalised"
+        matrix_type = "TPM" // must be either "raw", "filtered", "TPM" or "CPM"
         results_dir = "${baseDir}/outputs" // output for outer WF 
         training_10x_dir = "${baseDir}/data/data_10X"
         training_metadata = "${baseDir}/data/unmelted_sdrf.tsv"
@@ -71,8 +71,8 @@ params {
     }
 
     scmap_cluster{
-        run = "True"
-        matrix_type = "CPM" // must be either "raw", "filtered" or "normalised"
+        run = "False"
+        matrix_type = "CPM" // must be either "raw", "filtered", "TPM" or "CPM"
         results_dir = "${baseDir}/outputs" // output for outer WF 
         training_10x_dir = "${baseDir}/data/data_10X"
         training_metadata = "${baseDir}/data/unmelted_sdrf.tsv"
@@ -88,7 +88,7 @@ params {
 
     scpred{
         run = "False"
-        matrix_type = "" // must be either "raw", "filtered" or "normalised"
+        matrix_type = "CPM" // must be either "raw", "filtered", "TPM" or "CPM"
         results_dir = "${baseDir}/outputs" // specify output when in nested workflow
         method="prediction" //must be 'evaluation' or 'prediction'
         training_10x_dir = "$baseDir/data/test_10X_data"

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,6 +39,7 @@ params {
 
     garnett {
         run = "True" // boolean - should the sub-workflow be run (True/False)?
+        matrix_type = "CPM" // must be either "raw", "filtered" or "normalised"
         training_10x_dir = "$baseDir/data/data_10X"
         training_cds_gene_id_type = "ENSEMBL"
         training_dataset_id = ""
@@ -54,6 +55,7 @@ params {
 
     scmap_cell{
         run = "True"
+        matrix_type = "TPM" // must be either "raw", "filtered" or "normalised"
         results_dir = "${baseDir}/outputs" // output for outer WF 
         training_10x_dir = "${baseDir}/data/data_10X"
         training_metadata = "${baseDir}/data/unmelted_sdrf.tsv"
@@ -69,7 +71,8 @@ params {
     }
 
     scmap_cluster{
-        run = "False"
+        run = "True"
+        matrix_type = "CPM" // must be either "raw", "filtered" or "normalised"
         results_dir = "${baseDir}/outputs" // output for outer WF 
         training_10x_dir = "${baseDir}/data/data_10X"
         training_metadata = "${baseDir}/data/unmelted_sdrf.tsv"
@@ -85,6 +88,7 @@ params {
 
     scpred{
         run = "False"
+        matrix_type = "" // must be either "raw", "filtered" or "normalised"
         results_dir = "${baseDir}/outputs" // specify output when in nested workflow
         method="prediction" //must be 'evaluation' or 'prediction'
         training_10x_dir = "$baseDir/data/test_10X_data"

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,7 @@ profiles {
 }
 
 params {
-    profile = "standard"
+    profile = "cluster"
 
     data_import {
         training_dataset_ids="${baseDir}/data/test.txt"
@@ -33,7 +33,7 @@ params {
     }
 
     unmelt_sdrf {
-        run = "False"
+        run = "True"
         retain_types = "TRUE"
     }
 


### PR DESCRIPTION
This PR adds the logic to control for type of matrix used for each tool. 
- Parameters are retrieved and for each dataset, all matrix versions found in the config are imported. 
- If a tool is "off", it's matrix type is not included into the download list.
- Then, for each tool, relevant dataset type is selected and a classifier is trained.
- In cases when experiment technology is specified as 'droplet', CPM matrix will be downloaded even for those tools that require TPM matrix. For smart-seq experiments, matrix will be determined according to tool config.