### PR TITLE
Just a randome selection of tweaks made by Jon while testing for CAPSULE error

### DIFF
--- a/bin/run_control_workflow.sh
+++ b/bin/run_control_workflow.sh
@@ -2,4 +2,4 @@
 
 export WORKFLOW_ROOT=`pwd`
 
-nextflow run main.nf -profile $1
+nextflow run main.nf -profile $1 -resume

--- a/envs/exp_metadata.yaml
+++ b/envs/exp_metadata.yaml
@@ -1,8 +1,3 @@
 name: experiment-metadata
-channels:
-  - bioconda
-  - conda-forge
-  - defaults
-  - ebi-gene-expression-group
 dependencies:
-  - atlas-experiment-metadata
+  - atlas-experiment-metadata=0.0.6

--- a/envs/load_data.yaml
+++ b/envs/load_data.yaml
@@ -1,8 +1,3 @@
 name: data_import
-channels:
-  - bioconda
-  - conda-forge
-  - defaults
-  - ebi-gene-expression-group
 dependencies:
-  - atlas-data-import=0.0.5
+  - atlas-data-import=0.0.6

--- a/envs/nextflow.yaml
+++ b/envs/nextflow.yaml
@@ -1,7 +1,3 @@
 name: nextflow
-channels:
-  - bioconda
-  - conda-forge
-  - defaults
 dependencies:
   - nextflow=20.01.0

--- a/main.nf
+++ b/main.nf
@@ -62,6 +62,9 @@ if(params.unmelt_sdrf.run == "True"){
     process unmelt_condensed_sdrf {
         conda "${baseDir}/envs/exp_metadata.yaml"
 
+        memory { 10.GB * task.attempt }
+        errorStrategy { task.attempt<=5 ? 'retry' : 'ignore' }
+
         input:
             tuple file(data), val(dataset_id), val(barcode_col), val(cell_type_col), val(matrix_type) from TRAINING_DATA
 
@@ -110,9 +113,11 @@ if(params.garnett.run == "True"){
         maxRetries 5
         memory { 16.GB * task.attempt }
         
+        maxForks 3
+
         input:
             tuple val(num_clust), file(training_data), val(dataset_id), val(barcode_col), val(cell_label_col), val(matrix_type) from GARNETT_FILTERED_DATA
-            
+
         output:
             file("${dataset_id}_garnett.rds") into GARNETT_CLASSIFIER
 
@@ -149,10 +154,12 @@ if(params.scpred.run == "True"){
         publishDir "${baseDir}/data/${dataset_id}", mode: 'copy'
         conda "${baseDir}/envs/nextflow.yaml"
 
-        errorStrategy { task.exitStatus == 130 || task.exitStatus == 137  ? 'retry' : 'finish' }   
+        errorStrategy { task.exitStatus == 130 || task.exitStatus == 137  ? 'retry' : 'ignore' }   
         maxRetries 5
         memory { 16.GB * task.attempt }
 
+        maxForks 3
+        
         input:
             tuple file(training_data), val(dataset_id), val(barcode_col), val(cell_label_col), val(matrix_type) from SCPRED_FILTERED_DATA
 
@@ -195,10 +202,12 @@ if(params.scmap_cluster.run == "True"){
         publishDir "${baseDir}/data/${dataset_id}", mode: 'copy'
         conda "${baseDir}/envs/nextflow.yaml"
 
-        errorStrategy { task.exitStatus == 130 || task.exitStatus == 137  ? 'retry' : 'finish' }   
+        errorStrategy { task.exitStatus == 130 || task.exitStatus == 137  ? 'retry' : 'ignore' }   
         maxRetries 5
         memory { 16.GB * task.attempt }
 
+        maxForks 3
+        
         input:
             tuple file(training_data), val(dataset_id), val(barcode_col), val(cell_label_col), val(matrix_type) from SCMAP_CLUSTER_FILTERED_DATA
 
@@ -235,10 +244,12 @@ if(params.scmap_cell.run == "True"){
         publishDir "${baseDir}/data/${dataset_id}", mode: 'copy'
         conda "${baseDir}/envs/nextflow.yaml"
 
-        errorStrategy { task.exitStatus == 130 || task.exitStatus == 137  ? 'retry' : 'finish' }   
+        errorStrategy { task.exitStatus == 130 || task.exitStatus == 137  ? 'retry' : 'ignore' }   
         maxRetries 5
         memory { 16.GB * task.attempt }
 
+        maxForks 3
+        
         input:
             tuple file(training_data), val(dataset_id), val(barcode_col), val(cell_label_col), val(matrix_type) from SCMAP_CELL_FILTERED_DATA
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,6 +4,7 @@ profiles {
         process.executor = 'local'
         conda.cacheDir = "$WORKFLOW_ROOT/cached_envs"
 	conda.createTimeout = "30 min"
+        queueSize=1
     }
 
     cluster{
@@ -11,19 +12,19 @@ profiles {
         process.queue='production-rh74'
         process.clusterOptions = '-R \"select[hname!=\'hx-noah-05-02\']\"'
 
-        executor.queueSize=1000
         executor.perJobMemLimit=false
         executor.exitReadTimeout='100000 sec'
         executor.pollInterval = '5sec'
+        executor.queueSize=10
+	    executor.submitRateLimit = '1 / 5 s' 
 
         conda.cacheDir = "$WORKFLOW_ROOT/cached_envs" // TODO: sort out this path 
         conda.createTimeout = "30 min"
-	submitRateLimit = '1 / 15 s' 
     } 
 }
 
 params {
-    profile = "standard" // should the individual workflows be run as cluster jobs or as local processes? 
+    profile = "cluster" // should the individual workflows be run as cluster jobs or as local processes? 
 
     data_import {
         training_datasets="${baseDir}/data/datasets.txt"


### PR DESCRIPTION
I've done a bit of testing, managing to avoid a capsule error. I'm fairly sure that the capsule error is caused by multiple processes creating the same environment, e.g. for multiple instances of the same child workflow. This can also occur when the environment already exists when the file system is placed under very high load (with very high numbers of child processes), since Nextflow seems to try to re-create the environment (presumably not identifying a pre-existing environment when the file system responds slowly).

I would like to see the changes in this PR implemented in some form:

- Most importantly, limit concurrency. All of the following will limit the number of processes sourcing an environment at any one time. The settings in this PR may be conservative and might be increased carefully.
  - Make use of submission rate logic (needs to be in 'executor' context)
  - Limit queueSize
  - Limit number of running instances of each of the child workflows with 'maxForks'.
- Environment files should not dictate channels. I don't think the priority set there is foolproof (it certainly gave me many issues), so we should leave it to users to configure their channels properly per the the Bioconda instructions.
- The unmelt step needs resubmission logic
- Use cluster profile for child workflows so that their jobs also become individual cluster jobs.
- Use of 'resume' in the parent workflow execution to allow re-use of cached results
- Switch of atlas-data-import to 0.0.6. from 0.0.5 addressed a dependency conflict issue for me (unlike the most recent version which would need a change to the workflow I think). 

In the child workflows:

- Remove channels again (rely on global settings)
- Uncomment ' conda.cacheDir = "$WORKFLOW_ROOT/cached_envs"'  to reactivate use of the top-level environment dir. If we don't do this, then the child workflows will repeatedly re-create the environments. 

**Importantly:** 

The top-level workflow should be run with a single dataset initially, with queueSize set to 1, so that there is no possibility of multiple processes attempting to establish the same environment at the same time. Before doing this, delete the contents of your cached_envs and work directories (I've found that partial failures can leave things in these dirs that create issues). Once that single dataset has been processed correctly the environments will all be in place, the queueSize can be reset  to a higher value, and multiple datasets can be processed at once. 

